### PR TITLE
External links in new tabs and redirecting /cv

### DIFF
--- a/404.html
+++ b/404.html
@@ -2,7 +2,7 @@
 permalink: /404.html
 layout: default
 ---
-<div class="container error py-4 text-center">
+<div class="container message py-4 text-center">
   <h1 class="display-2 pt-5">404</h1>
   <h4>Page not found :(</h4>
   <p>The requested page could not be found.</p>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -9,7 +9,8 @@
     <div class="collapse navbar-collapse" id="navbarNav">
       <div class="navbar-nav">
         {% for item in site.data.navigation.pages %}
-          <a class="nav-item nav-link {% if item.url == page.url %}active{% endif %}" href="{{ item.url }}">{{ item.title }}
+          <a class="nav-item nav-link {% if item.url == page.url %}active{% endif %}" href="{{ item.url }}"
+             target="{% if item.title == "CV" %}_blank{% endif %}">{{ item.title }}
             <span class="sr-only">(current)</span></a>
         {% endfor %}
       </div>

--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -1,0 +1,10 @@
+---
+layout: default
+---
+<div class="container message py-4 text-center">
+    <h1 class="pt-5">Redirecting...</h1>
+    <p class="small">
+        <a href="{{ page.redirect_to }}">Click here if you are not redirected.<a>
+            <script>location="{{ page.redirect_to }}"</script>
+    </p>
+</div>

--- a/css/custom/custom.scss
+++ b/css/custom/custom.scss
@@ -2,8 +2,8 @@ a:hover  {
   text-decoration: none;
 }
 
-/* 404 */
-.container.error {
+/* For big messages that should take the whole page (e.g. 404, redirect) */
+.container.message {
   height: 100vh;
   overflow:hidden;
 }

--- a/cv.md
+++ b/cv.md
@@ -1,0 +1,5 @@
+---
+layout: redirect
+sitemap: false
+redirect_to: https://www.dropbox.com/s/cpmupnfig8595uk/Miguel%20Jimenez%20-%20Resume.pdf?dl=0
+---

--- a/index.markdown
+++ b/index.markdown
@@ -2,19 +2,19 @@
 title: Miguel Jimenez
 layout: index
 about: |
-    Junior Computer Science Student at Concordia University. I have interned at [GitHub](https://github.com) and the 
-    Montreal start-up [E-Panneur](https://e-panneur.ca) as a Rails web developer. I have developed a special relationship 
-    with REST, APIs and building and coming up with exciting ideas. I like to think this software development path started 
-    when my godfather gave me a PlayStation 2 🎮 when I was 5. Since then, I have not stopped playing video games, which 
-    led me to create and think of spin-offs and mods I could write. And to be able to do that I needed to know how to 
-    code, so here I am 🙋‍♂️️.
+    Junior Computer Science Student at Concordia University. I have interned at [GitHub](https://github.com){:target="_blank"} 
+    and the Montreal start-up [E-Panneur](https://e-panneur.ca){:target="_blank"} as a Rails web developer. 
+    I have developed a special relationship with REST, APIs and building and coming up with exciting ideas. I like to 
+    think this software development path started when my godfather gave me a PlayStation 2 🎮 when I was 5. Since then, 
+    I have not stopped playing video games, which led me to create and think of spin-offs and mods I could write. 
+    And to be able to do that I needed to know how to code, so here I am 🙋‍♂️️.
     >
     Besides coding and video games, music, movies, hiking, traveling and soccer are my jam. Check out my
     [music collection]() and [travel journals]()!
 timeline:
     - title: Software Engineering Intern - Marketplace
       subtitle: |
-        [GitHub](https://github.com) - San Francisco, California
+        [GitHub](https://github.com){:target="_blank"} - San Francisco, California
       year: Jun 2019 - August 2019
       description: |
         • Created a RESTful microservice to categorize more than 150 GitHub Apps using machine learning. This has made the number of apps in Marketplace double. 
@@ -26,7 +26,7 @@ timeline:
         • Technologies: Ruby on Rails, HTML, CSS, GraphQL, SQL, Docker, Kubernetes.
     - title: Amazon Student Prime Ambassador (Contract)
       subtitle: |
-        [Student Life Network & Parent Life Network](https://studentlifenetwork.com) - Montreal, Quebec
+        [Student Life Network & Parent Life Network](https://studentlifenetwork.com){:target="_blank"} - Montreal, Quebec
       year: Aug 2018 - Feb 2019
       description: |
         • Increased awareness of the Prime Student membership and its benefits to students by having more than 250 interactions every week.
@@ -36,7 +36,7 @@ timeline:
         • Used a marketing approach of digital, experiential, and peer-to-peer tactics to reach as many students as possible.
     - title: Software Intern
       subtitle: |
-        [E-Panneur](https://e-panneur.ca) - Montreal, Quebec
+        [E-Panneur](https://e-panneur.ca){:target="_blank"} - Montreal, Quebec
       year: May 2017 - Aug 2017
       description: |
         • Developed a RESTful web service with tools for administrators to manage incoming orders and shipments.
@@ -50,13 +50,13 @@ timeline:
       subtitle: Concordia University - Montreal, Quebec
       year: Sep 2016 - May 2021
       description: |
-        • In 2018, at the hackathon [ConUHacks](https://conuhacks.io) III, made calls to different APIs to recommend 
+        • In 2018, at the hackathon [ConUHacks](https://conuhacks.io){:target="_blank"} III, made calls to different APIs to recommend 
         activities based on geolocation.
         >
-        • In 2017, At the hackathon [ConUHacks](https://conuhacks.io) II, built a Twitter bot that would scan tweets containing 
+        • In 2017, At the hackathon [ConUHacks](https://conuhacks.io){:target="_blank"} II, built a Twitter bot that would scan tweets containing 
         a hashtag, and reply to them.
         >
-        • In freshman year, participated in the student club [Space Concordia](https://spaceconcordia.github.io) where
+        • In freshman year, participated in the student club [Space Concordia](https://spaceconcordia.github.io){:target="_blank"} where
         I redesigned and implemented an interface (GUI) used for visualizing and controlling a space rover for the 
-        [University Rover Challenge](http://urc.marssociety.org) (URC).
+        [University Rover Challenge](http://urc.marssociety.org){:target="_blank"} (URC).
 ---


### PR DESCRIPTION
Closes: #2, #9

## Loading external links on new tabs

Links were loading on the same tab, taking traffic off the site.

Now, if the the link is external, it will load that page on another tab.

![047860b4de16b086d0cb5d9fe9572245](https://user-images.githubusercontent.com/10281272/65542311-ed7bdd80-dedc-11e9-9823-2bbe64cdce9c.gif)

## Redirect /cv to external link

"CV" was visible on the nav bar, yet the route `/cv` was returning a 404.

/cv will now redirect the user to the resume.

![6af743166e2c4d46401141b09de7b94e](https://user-images.githubusercontent.com/10281272/65542448-30d64c00-dedd-11e9-9975-d923b7bcb111.gif)

Moreover, when accessing "CV" on the nav bar, this will open the resume in a new tab since it is an external link.

![0894d54d0e15975881ecade83d2be17d](https://user-images.githubusercontent.com/10281272/65542540-624f1780-dedd-11e9-8673-d2c295c41d75.gif)


